### PR TITLE
POC for using environment variables to override internal dependency branches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,12 @@ features = [
     "build",
 ]
 
+[tool.hatch.envs.default.overrides]
+dependencies = [
+    { value = "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@$(HATCH_DBT_ADAPTERS_BRANCH)", env = ["HATCH_DBT_ADAPTERS_BRANCH"] },
+    { value = "dbt_common @ git+https://github.com/dbt-labs/dbt-common.git@$(HATCH_DBT_COMMON_BRANCH)", env = ["HATCH_DBT_COMMON_BRANCH"] },
+]
+
 [tool.hatch.envs.lint]
 detached = true
 features = ["lint"]


### PR DESCRIPTION
resolves #15

### Problem

We need to be able to run integration tests, and possibly unit tests, against a branch other than `main` for internal dependencies (e.g. `dbt-common`, `dbt-adapters`).

### Solution

Try creating dependency overrides based on environmental variables. The goal is to enable running this in GHA via inputs as well as running this locally by updating `test.env`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
