### PR TITLE
Change input references to make documentation recommendations.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -71,8 +71,8 @@ jobs:
         shell: bash
         run: |
           ./.github/scripts/update_dev_packages.sh \
-            ${{ github.event.inputs.dbt_adapters_branch }} \
-            ${{ github.event.inputs.core_branch }}
+            ${{ inputs.dbt_adapters_branch }} \
+            ${{ inputs.core_branch }}
 
       - name: Setup postgres
         shell: bash


### PR DESCRIPTION
### Problem

The workflow is failing to carry through inputs or even defaults. I'm pretty sure the namespacing on the variables is to blame. `github.event` may be deprecated. Docs recommend things like `on.workflow_dispatch.inputs` nowadays if one wanted that control.

### Solution

Trim off the prefix to just be `inputs`. 