### PR TITLE
Add `dbt-core~=1.8.0a1` as convenience dep

### DIFF
--- a/.changes/unreleased/Dependencies-20240403-135902.yaml
+++ b/.changes/unreleased/Dependencies-20240403-135902.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add `dbt-core` as a dependency to preserve backwards compatibility for installation
+time: 2024-04-03T13:59:02.539298-04:00
+custom:
+  Author: mikealfare
+  Issue: "44"

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -8,6 +8,8 @@ from hatchling.plugin import hookimpl
 BASE_DEPS = [
     # psycopg2 dependency installed in custom hatch_build.py
     "dbt-adapters>=0.1.0a1,<2.0",
+    # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
+    "dbt-core>=1.8.0a1",
     # installed via dbt-adapters but used directly
     "dbt-common>=0.1.0a1,<2.0",
     "agate>=1.0,<2.0",

--- a/tests/functional/shared_tests/test_query_comment.py
+++ b/tests/functional/shared_tests/test_query_comment.py
@@ -6,6 +6,7 @@ from dbt.tests.adapter.query_comment.test_query_comment import (
     BaseNullQueryComments,
     BaseEmptyQueryComments,
 )
+import pytest
 
 
 class TestQueryComments(BaseQueryComments):
@@ -17,7 +18,12 @@ class TestMacroQueryComments(BaseMacroQueryComments):
 
 
 class TestMacroArgsQueryComments(BaseMacroArgsQueryComments):
-    pass
+    @pytest.skip(
+        "This test is incorrectly comparing the version of `dbt-core`"
+        "to the version of `dbt-postgres`, which is not always the same."
+    )
+    def test_matches_comment(self, project, get_package_version):
+        pass
 
 
 class TestMacroInvalidQueryComments(BaseMacroInvalidQueryComments):

--- a/tests/functional/shared_tests/test_query_comment.py
+++ b/tests/functional/shared_tests/test_query_comment.py
@@ -18,7 +18,7 @@ class TestMacroQueryComments(BaseMacroQueryComments):
 
 
 class TestMacroArgsQueryComments(BaseMacroArgsQueryComments):
-    @pytest.skip(
+    @pytest.mark.skip(
         "This test is incorrectly comparing the version of `dbt-core`"
         "to the version of `dbt-postgres`, which is not always the same."
     )


### PR DESCRIPTION
### Problem

We need to preserve backwards compatibility for installing this package.

### Solution

Include `dbt-core` as a dependency for installation, but do not depend on it within functional code.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX