### PR TITLE
Skip inapplicable test that compares `dbt-core`'s version to that of `dbt-postgres`

### DIFF
--- a/tests/functional/shared_tests/test_query_comment.py
+++ b/tests/functional/shared_tests/test_query_comment.py
@@ -6,6 +6,7 @@ from dbt.tests.adapter.query_comment.test_query_comment import (
     BaseNullQueryComments,
     BaseEmptyQueryComments,
 )
+import pytest
 
 
 class TestQueryComments(BaseQueryComments):
@@ -17,7 +18,13 @@ class TestMacroQueryComments(BaseMacroQueryComments):
 
 
 class TestMacroArgsQueryComments(BaseMacroArgsQueryComments):
-    pass
+
+    @pytest.skip(
+        "This test is incorrectly comparing the version of `dbt-core`"
+        "to the version of `dbt-postgres`, which is not always the same."
+    )
+    def test_matches_comment(self, project, get_package_version):
+        pass
 
 
 class TestMacroInvalidQueryComments(BaseMacroInvalidQueryComments):


### PR DESCRIPTION
### Problem

The test compares `dbt-core`'s version to that of `dbt-postgres`. This is not always true though, as different versions could be published to PyPI at the same time.

### Solution

- Manually inspect the test to ensure the actual expected version is there
- Skip the test
- Release
- Resolve the test in the future, or elect to remove it as these two packages are now decoupled

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
