### PR TITLE
Add version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,28 @@
+# **what?**
+# This workflow will take the new version number to bump to. With that
+# it will run versionbump to update the version number everywhere in the
+# code base and then run changie to create the corresponding changelog.
+# A PR will be created with the changes that can be reviewed before committing.
+
+# **why?**
+# This is to aid in releasing dbt and making sure we have updated
+# the version in all places and generated the changelog.
+
+# **when?**
+# This is triggered manually
+
+name: Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+       description: 'The version number to bump to (ex. 1.2.0, 1.3.0b1)'
+       required: true
+
+jobs:
+  version_bump_and_changie:
+    uses: dbt-labs/actions/.github/workflows/version-bump.yml@main
+    with:
+      version_number: ${{ inputs.version_number }}
+    secrets: inherit  # ok since what we are calling is internally maintained


### PR DESCRIPTION
### Problem

We manually manage version bumping and changelog consolidation because this is a new repo.

### Solution

Add the version-bump workflow. The result will look similar to what `dbt-spark` does.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
