### PR TITLE
Pin `macos` test runners to `macos-12`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -108,7 +108,7 @@ jobs:
       matrix:
         scenario:
           - {platform: ubuntu-latest, psycopg2-name: psycopg2}
-          - {platform: macos-latest, psycopg2-name: psycopg2-binary}
+          - {platform: macos-12, psycopg2-name: psycopg2-binary}
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4


### PR DESCRIPTION
### Problem

`macos-latest` now points to `macos-14-arm64`; it used to point to `macos-12`. There is no `py39` nor `py38` on `macos-14-arm64`.

### Solution

Pin to `macos-12` for now and discuss long term options to use `macos-14-arm64`, and CI pinning in general.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX