### PR TITLE
[Bug] Use a list instead of a set for index changes to perserve order

### DIFF
--- a/.changes/unreleased/Fixes-20240425-133401.yaml
+++ b/.changes/unreleased/Fixes-20240425-133401.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Fix issue where index updates were occassionally happening out of order
+body:  Replace usage of `Set` with `List` to fix issue with index updates intermittently happening out of order
 time: 2024-04-25T13:34:01.018399-04:00
 custom:
   Author: mikealfare

--- a/.changes/unreleased/Fixes-20240425-133401.yaml
+++ b/.changes/unreleased/Fixes-20240425-133401.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix issue where index updates were occassionally happening out of order
+time: 2024-04-25T13:34:01.018399-04:00
+custom:
+  Author: mikealfare
+  Issue: "72"

--- a/dbt/adapters/postgres/relation_configs/materialized_view.py
+++ b/dbt/adapters/postgres/relation_configs/materialized_view.py
@@ -101,7 +101,7 @@ class PostgresMaterializedViewConfig(RelationConfigBase, RelationConfigValidatio
 
 @dataclass
 class PostgresMaterializedViewConfigChangeCollection:
-    indexes: Set[PostgresIndexConfigChange] = field(default_factory=set)
+    indexes: List[PostgresIndexConfigChange] = field(default_factory=list)
 
     @property
     def requires_full_refresh(self) -> bool:
@@ -109,4 +109,4 @@ class PostgresMaterializedViewConfigChangeCollection:
 
     @property
     def has_changes(self) -> bool:
-        return self.indexes != set()
+        return self.indexes != []

--- a/tests/unit/test_materialized_view.py
+++ b/tests/unit/test_materialized_view.py
@@ -1,0 +1,56 @@
+from copy import deepcopy
+
+from dbt.adapters.contracts.relation import RelationType
+from dbt.adapters.relation_configs.config_change import RelationConfigChangeAction
+
+from dbt.adapters.postgres.relation import PostgresRelation
+from dbt.adapters.postgres.relation_configs import PostgresIndexConfig
+
+
+def test_index_config_changes():
+    index_0_old = {
+        "column_names": {"column_0"},
+        "unique": True,
+        "method": "btree",
+    }
+    index_1_old = {
+        "column_names": {"column_1"},
+        "unique": True,
+        "method": "btree",
+    }
+    index_2_old = {
+        "column_names": {"column_2"},
+        "unique": True,
+        "method": "btree",
+    }
+    existing_indexes = frozenset(
+        PostgresIndexConfig.from_dict(index) for index in [index_0_old, index_1_old, index_2_old]
+    )
+
+    index_0_new = deepcopy(index_0_old)
+    index_2_new = deepcopy(index_2_old)
+    index_2_new.update(method="hash")
+    index_3_new = {
+        "column_names": {"column_3"},
+        "unique": True,
+        "method": "hash",
+    }
+    new_indexes = frozenset(
+        PostgresIndexConfig.from_dict(index) for index in [index_0_new, index_2_new, index_3_new]
+    )
+
+    relation = PostgresRelation.create(
+        database="my_database",
+        schema="my_schema",
+        identifier="my_materialized_view",
+        type=RelationType.MaterializedView,
+    )
+
+    index_changes = relation._get_index_config_changes(existing_indexes, new_indexes)
+
+    assert isinstance(index_changes, list)
+    assert len(index_changes) == len(["drop 1", "drop 2", "create 2", "create 3"])
+    assert index_changes[0].action == RelationConfigChangeAction.drop
+    assert index_changes[1].action == RelationConfigChangeAction.drop
+    assert index_changes[2].action == RelationConfigChangeAction.create
+    assert index_changes[3].action == RelationConfigChangeAction.create

--- a/tests/unit/test_materialized_view.py
+++ b/tests/unit/test_materialized_view.py
@@ -9,16 +9,19 @@ from dbt.adapters.postgres.relation_configs import PostgresIndexConfig
 
 def test_index_config_changes():
     index_0_old = {
+        "name": "my_index_0",
         "column_names": {"column_0"},
         "unique": True,
         "method": "btree",
     }
     index_1_old = {
+        "name": "my_index_1",
         "column_names": {"column_1"},
         "unique": True,
         "method": "btree",
     }
     index_2_old = {
+        "name": "my_index_2",
         "column_names": {"column_2"},
         "unique": True,
         "method": "btree",
@@ -31,6 +34,7 @@ def test_index_config_changes():
     index_2_new = deepcopy(index_2_old)
     index_2_new.update(method="hash")
     index_3_new = {
+        "name": "my_index_3",
         "column_names": {"column_3"},
         "unique": True,
         "method": "hash",


### PR DESCRIPTION
resolves #72

### Problem

We are using a set for the index changes on materialized views. A set is not ordered, which leads to the changes occasionally happening out of order. This is a problem when an index with the same name is being replaced as that has to happen in a particular order (drop first).

### Solution

Use a list instead of a set.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
