### PR TITLE
[WIP] - Partitioning support

### DIFF
--- a/dbt/include/postgres/macros/adapters.sql
+++ b/dbt/include/postgres/macros/adapters.sql
@@ -108,7 +108,7 @@
     {% set existing_partitions_query %}
       select
         inhrelid::regclass as from_table_name,
-        regexp_substr(inhrelid::regclass::text, '[^_]*$') as partition_suffix -- Get the string after the last underscore
+        '_' || regexp_substr(inhrelid::regclass::text, '[^_]*$') as partition_suffix -- Get the string after the last underscore
       from pg_inherits i
       join pg_class c on i.inhparent = c.oid
       join pg_namespace ns on c.relnamespace = ns.oid

--- a/dbt/include/postgres/macros/adapters.sql
+++ b/dbt/include/postgres/macros/adapters.sql
@@ -107,10 +107,12 @@
     {# If the relation is partitioned, rename the subtables #}
     {% set existing_partitions_query %}
       select
-        inhrelid::regclass::text as from_table_name,
+        inhrelid::regclass as from_table_name,
         regexp_substr(inhrelid::regclass::text, '[^_]*$') as partition_suffix -- Get the string after the last underscore
-      from pg_catalog.pg_inherits
-      where inhparent = '{{ from_relation.schema }}.{{ from_relation.identifier }}'::regclass;
+      from pg_inherits i
+      join pg_class c on i.inhparent = c.oid
+      join pg_namespace ns on c.relnamespace = ns.oid
+      where ns.nspname = '{{ from_relation.schema }}' and c.relname = '{{ from_relation.identifier }}';
     {% endset %}
     {% set existing_partitions_results = run_query(existing_partitions_query) %}
 

--- a/dbt/include/postgres/macros/materializations/incremental_strategies.sql
+++ b/dbt/include/postgres/macros/materializations/incremental_strategies.sql
@@ -1,9 +1,83 @@
-{% macro postgres__get_incremental_default_sql(arg_dict) %}
+{% macro postgres__get_incremental_merge_sql(arg_dict) %}
+  {{ create_incremental_missing_partitions(arg_dict) }}
 
-  {% if arg_dict["unique_key"] %}
-    {% do return(get_incremental_delete_insert_sql(arg_dict)) %}
-  {% else %}
-    {% do return(get_incremental_append_sql(arg_dict)) %}
-  {% endif %}
+  {% do return(default__get_incremental_merge_sql(arg_dict)) %}  
+{% endmacro %}
+
+{% macro postgres__get_incremental_delete_insert_sql(arg_dict) %}
+  {{ create_incremental_missing_partitions(arg_dict) }}
+
+  {% do return(default__get_incremental_delete_insert_sql(arg_dict)) %}
+{% endmacro %}
+
+{% macro postgres__get_incremental_append_sql(arg_dict) %}
+  {{ create_incremental_missing_partitions(arg_dict) }}
+
+  {% do return(default__get_incremental_append_sql(arg_dict)) %}
+{% endmacro %}
+
+{% macro create_incremental_missing_partitions(arg_dict) %}
+  {%- set target = arg_dict["target_relation"] -%}
+  {%- set source = arg_dict["temp_relation"] -%}
+  {%- set unlogged = config.get('unlogged') %}
+
+  {#
+    -- New data might get inserted to a partition that still does not exist
+    -- We need to perform an anti join between the partitions that exist in the new (source) table and the target table
+    -- Partitions that don't exist will be created
+  #}
+  {%- set missing_partitions_query %}
+  with
+    new_partitions as (
+      -- Get the partitions present on the new, temporary source table
+      select
+        inhrelid::regclass as from_table_name,
+        regexp_substr(inhrelid::regclass::text, '[^_]*$') as partition_suffix, -- Get the string after the last underscore
+        pg_get_expr(c.relpartbound, c.oid, true) as partition_expression
+      from pg_inherits i
+      join pg_class c_parent on i.inhparent = c_parent.oid
+      join pg_class c on i.inhrelid = c.oid
+      where c.relnamespace = pg_my_temp_schema()::regclass
+        and c_parent.relname = '{{ source.identifier }}'
+    ),
+    existing_partitions as (
+      -- Partitions already available on the target table
+      select
+        pg_get_expr(c.relpartbound, c.oid, true) as partition_expression
+      from pg_inherits i
+      join pg_class c_parent on i.inhparent = c_parent.oid
+      join pg_class c on i.inhrelid = c.oid
+      join pg_namespace ns on c.relnamespace = ns.oid
+      where ns.nspname = '{{ target.schema }}' and c_parent.relname = '{{ target.identifier }}'
+    ),
+    missing_partitions as (
+      -- Find the partitions that exist on the source table but not on the target
+      select
+        np.from_table_name,
+        partition_suffix,
+        partition_expression
+      from new_partitions np
+      left join existing_partitions ep using (partition_expression)
+      where ep.partition_expression is null
+    )
+    select *
+    from missing_partitions
+  {% endset %}
+
+  {% set missing_partitions = run_query(missing_partitions_query) %}
+  {% for missing_partition in missing_partitions.rows %}
+    {%- set partition_relation = make_intermediate_relation(target, missing_partition['partition_suffix']) %}
+
+    -- Create the missing partition
+    create {% if unlogged -%}
+        unlogged
+      {%- endif %} 
+      table
+    "{{ target.schema }}"."{{ partition_relation.identifier }}"
+    partition of {{ target }} {{ missing_partition.partition_expression }};
+  {% endfor %}
+
+  {# Ensure a statement is executed even if no new partitions were created #}
+  select 1;
 
 {% endmacro %}


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-adapters/issues/679

### Problem

This is a draft PR adding partitioning support for Postgres as stated on https://github.com/dbt-labs/dbt-adapters/issues/679. It doesn't use dbt coding best practices and lacks, but it works. I'm opening it to gather feedback on how to proceed.

Syntax is copied from on dbt-bigquery partitioning:
```
{{ config(
    materialized = 'table',
    partition_by = {
      "field": "created_at",
      "granularity": "month"
    }
) }}

select generate_series(current_date - interval '1000 day', current_date, '1 month'::interval)::date as created_at,
        'hello' as dummy_text
```

Benefits this brings:
- Postgres doesn't allow to partition an existing table. If dbt creates an initially partitioned table, a DBA can then manually tune them or use pg_partman extension over it. That's not possible unless dbt is able to create partitioned tables.
- When using insert+write incremental strategy, you can change the access method of old partitions to Citus columnar or Hydra, which don't allow deletes or updates. Incremental methods are currently not currently usable on those environments.

Moreover, creating a custom incremental strategy replacing partitions is then relatively easy as shown in https://github.com/dbt-labs/dbt-adapters/issues/679. That incremental strategy is out of scope for this PR as there are a lot of possible variations.

IMO this patch is already in a stage that can be reviewed. I would help on some best practices and adding tests though.

### Solution

To Do:

- [ ] Contract config is not enforced
- [ ] Tests
- [ ] Partitioning means executing the SQL model twice, or temporarily storing it twice. This need to be documented.
- [x] Partition names concatenate the start day of the partition (regardless of granularity). Names longer than the maximum 64 characters are still not handlded correctly. 
- [x] ~~Add a default partition to handle uncovered ranges. Without specific partition support on incremental strategies, one must handle creation of future partitions. This can be done via a cron job or manually. Having a default partition means inserts won't fail.~~ Handle incremental partitions
- [ ] handle adding of new fields to the parent table

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
