### PR TITLE
Add branch param to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         - prod
         - test
         default: prod
+      ref:
+        description: "The ref (sha or branch name) to use"
+        type: string
+        default: "main"
+        required: true
 
 permissions: read-all
 
@@ -33,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          ref: "${{ inputs.ref }}"
 
       - name: Setup `hatch`
         uses: dbt-labs/dbt-adapters/.github/actions/setup-hatch@main


### PR DESCRIPTION
### Problem

We need the branch name in the dispatch for postgres to properly release rcX versions. 


### Solution

I added the branch ref as a param along with sending that ref to the checkout step.
