### PR TITLE
Fix the semicolon semantics for indexes while respecting other bug fix.

### DIFF
--- a/.changes/unreleased/Fixes-20240514-193201.yaml
+++ b/.changes/unreleased/Fixes-20240514-193201.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix the semicolon semantics for indexes while respecting other bug fix
+time: 2024-05-14T19:32:01.149383-07:00
+custom:
+  Author: versusfacit
+  Issue: "85"

--- a/dbt/include/postgres/macros/relations/materialized_view/alter.sql
+++ b/dbt/include/postgres/macros/relations/materialized_view/alter.sql
@@ -30,13 +30,14 @@
 
         {%- if _index_change.action == "drop" -%}
 
-            {{ postgres__get_drop_index_sql(relation, _index.name) }};
+            {{ postgres__get_drop_index_sql(relation, _index.name) }}
 
         {%- elif _index_change.action == "create" -%}
 
             {{ postgres__get_create_index_sql(relation, _index.as_node_config) }}
 
         {%- endif -%}
+	{{ ';' if not loop.last else "" }}
 
     {%- endfor -%}
 

--- a/dbt/include/postgres/macros/relations/materialized_view/create.sql
+++ b/dbt/include/postgres/macros/relations/materialized_view/create.sql
@@ -2,7 +2,7 @@
     create materialized view if not exists {{ relation }} as {{ sql }};
 
     {% for _index_dict in config.get('indexes', []) -%}
-        {{- get_create_index_sql(relation, _index_dict) -}}
+        {{- get_create_index_sql(relation, _index_dict) -}}{{ ';' if not loop.last else "" }}
     {%- endfor -%}
 
 {% endmacro %}

--- a/tests/functional/test_multiple_indexes.py
+++ b/tests/functional/test_multiple_indexes.py
@@ -1,0 +1,27 @@
+import pytest
+
+from tests.functional.utils import run_dbt
+
+
+REF_MULTIPLE_INDEX_MODEL = """
+{{
+    config(
+        materialized="materialized_view",
+        indexes=[
+            {"columns": ["foo"], "type": "btree"},
+            {"columns": ["bar"], "type": "btree"},
+        ],
+    )
+}}
+
+SELECT 1 AS foo, 2 AS bar
+"""
+
+
+class TestUnrestrictedPackageAccess:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"index_test.sql": REF_MULTIPLE_INDEX_MODEL}
+
+    def test_unrestricted_protected_ref(self, project):
+        run_dbt()


### PR DESCRIPTION
resolves #85 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#


### Problem
<img width="963" alt="image" src="https://github.com/dbt-labs/dbt-postgres/assets/67295367/1f964b94-5b5d-4609-a5e8-dc53bfde8d42">

Reprex now added as test and replicated locally!

@mikealfare shared this lovely context, re the comment linked in the issue ticket ([here](https://github.com/dbt-labs/dbt-core/pull/9959/files#r1569172176)). We removed a `;` at the `postgres__get_create_index_sql` macro to solve a different problem sending up empty queries when getting [this merged](https://github.com/dbt-labs/dbt-core/pull/9959):
> We do not appear to be updating cache for MV functionality like drops, renames, adds which is causing catalog mismatch errors in runs especially between MV's that are dependent on each other

This however was incomplete as a solution because we needed to only leave off the _last_ `;` from various index create/alter statements.

### Solution

<img width="963" alt="image" src="https://github.com/dbt-labs/dbt-postgres/assets/67295367/3e05929e-8112-4f69-80dd-3bd58e5b614c">


### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
