### PR TITLE
Add a changelog entry check for pull requests

### DIFF
--- a/.github/workflows/changelog-entry-check.yml
+++ b/.github/workflows/changelog-entry-check.yml
@@ -22,8 +22,8 @@ jobs:
         uses: dbt-labs/actions/.github/workflows/changelog-existence.yml@main
         with:
             changelog_comment: |-
-                "Thank you for your pull request!"
-                "We could not find a changelog entry for this change."
-                "For details on how to document a change, see the [dbt-postgres contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md)."
+                Thank you for your pull request!
+                We could not find a changelog entry for this change.
+                For details on how to document a change, see the [dbt-postgres contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md).
             skip_label: "Skip Changelog"
         secrets: inherit

--- a/.github/workflows/changelog-entry-check.yml
+++ b/.github/workflows/changelog-entry-check.yml
@@ -21,9 +21,9 @@ jobs:
     changelog-entry-check:
         uses: dbt-labs/actions/.github/workflows/changelog-existence.yml@main
         with:
-            changelog_comment: |-
-                Thank you for your pull request!
-                We could not find a changelog entry for this change.
-                For details on how to document a change, see the [dbt-postgres contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md).
+            changelog_comment: >-
+                Thank you for your pull request! We could not find a changelog entry for this change.
+                For details on how to document a change, see the [dbt-postgres contributing guide]
+                (https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md).
             skip_label: "Skip Changelog"
         secrets: inherit

--- a/.github/workflows/changelog-entry-check.yml
+++ b/.github/workflows/changelog-entry-check.yml
@@ -21,7 +21,7 @@ jobs:
     changelog-entry-check:
         uses: dbt-labs/actions/.github/workflows/changelog-existence.yml@main
         with:
-            changelog_comment: |
+            changelog_comment: -<
                 "Thank you for your pull request!"
                 "We could not find a changelog entry for this change."
                 "For details on how to document a change, see the [dbt-postgres contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md)."

--- a/.github/workflows/changelog-entry-check.yml
+++ b/.github/workflows/changelog-entry-check.yml
@@ -23,7 +23,7 @@ jobs:
         with:
             changelog_comment: >-
                 Thank you for your pull request! We could not find a changelog entry for this change.
-                For details on how to document a change, see the [dbt-postgres contributing guide]
-                (https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md).
+                For details on how to document a change, see the
+                [dbt-postgres contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md).
             skip_label: "Skip Changelog"
         secrets: inherit

--- a/.github/workflows/changelog-entry-check.yml
+++ b/.github/workflows/changelog-entry-check.yml
@@ -2,12 +2,12 @@ name: Changelog entry check
 
 on:
     pull_request:
-      types:
-      -   opened
-      -   reopened
-      -   labeled
-      -   unlabeled
-      -   synchronize
+        types:
+        -   opened
+        -   reopened
+        -   labeled
+        -   unlabeled
+        -   synchronize
 
 defaults:
     run:

--- a/.github/workflows/changelog-entry-check.yml
+++ b/.github/workflows/changelog-entry-check.yml
@@ -1,0 +1,29 @@
+name: Changelog entry check
+
+on:
+    pull_request:
+      types:
+      -   opened
+      -   reopened
+      -   labeled
+      -   unlabeled
+      -   synchronize
+
+defaults:
+    run:
+        shell: bash
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    changelog-entry-check:
+        uses: dbt-labs/actions/.github/workflows/changelog-existence.yml@main
+        with:
+            changelog_comment: |
+                "Thank you for your pull request!"
+                "We could not find a changelog entry for this change."
+                "For details on how to document a change, see the [dbt-postgres contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md)."
+            skip_label: "Skip Changelog"
+        secrets: inherit

--- a/.github/workflows/changelog-entry-check.yml
+++ b/.github/workflows/changelog-entry-check.yml
@@ -21,7 +21,7 @@ jobs:
     changelog-entry-check:
         uses: dbt-labs/actions/.github/workflows/changelog-existence.yml@main
         with:
-            changelog_comment: -<
+            changelog_comment: |-
                 "Thank you for your pull request!"
                 "We could not find a changelog entry for this change."
                 "For details on how to document a change, see the [dbt-postgres contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md)."


### PR DESCRIPTION
resolves #57

### Problem

We don't have a check for changelog entries on pull requests, which could lead to changes not being captured in the release changelog.

### Solution

Add the check that we have in other adapter repos.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
