### PR TITLE
Update test to handle moving from microbatch environment variable to behavior flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ path = "dbt/adapters/postgres/__version__.py"
 
 [tool.hatch.envs.default]
 dependencies = [
-    "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git",
+    "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@microbatch-behavior-flag",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-tests-adapter @ git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter",
-    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
+    "dbt-tests-adapter @ git+https://github.com/dbt-labs/dbt-adapters.git@microbatch-behavior-flag#subdirectory=dbt-tests-adapter",
+    "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git@microbatch-project-flags#subdirectory=core",
     "pre-commit==3.7.0",
     "freezegun",
     "pytest",


### PR DESCRIPTION
resolves #N/A

### Problem

dbt-adapters and dbt-core are moving from using an environment variable for gating microbatch functionality to a behavior flag (https://github.com/dbt-labs/dbt-adapters/pull/323, https://github.com/dbt-labs/dbt-core/pull/10799). Additionally, dbt-adapters is adding more test stubs around this, and we wan to use those test stubs

### Solution

Use the test stubs provided by dbt-adapters to test the switch from environment variable for gating microbatch functionality to a behavior flag.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
