### PR TITLE
[Bug 1.8.latest] Pin build dependencies to final releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ classifiers = [
 ]
 dependencies = [
     "psycopg2-binary>=2.9,<3.0",
-    "dbt-adapters>=0.1.0a1,<2.0",
+    "dbt-adapters>=0.1.0,<2.0",
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-    "dbt-core>=1.8.0a1",
+    "dbt-core>=1.8.0",
     # installed via dbt-adapters but used directly
-    "dbt-common>=0.1.0a1,<2.0",
+    "dbt-common>=0.1.0,<2.0",
     "agate>=1.0,<2.0",
 ]
 


### PR DESCRIPTION
### Problem

We never updated build dependencies to final releases when we cut the `1.8.latest` branch.

### Solution

Update pins for `dbt-common`, `dbt-adapters`, and `dbt-core`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
