### PR TITLE
Use `sql` instead of `compiled_code` within the default `get_limit_sql` macro

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,9 @@ path = "dbt/adapters/postgres/__version__.py"
 
 [tool.hatch.envs.default]
 dependencies = [
-    "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git",
+    "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git@dbeatty/fix-370",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-tests-adapter @ git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter",
+    "dbt-tests-adapter @ git+https://github.com/dbt-labs/dbt-adapters.git@dbeatty/fix-370#subdirectory=dbt-tests-adapter",
     "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
     "pre-commit==3.7.0",
     "freezegun",


### PR DESCRIPTION
### Problem

https://github.com/dbt-labs/dbt-adapters/pull/372#issuecomment-2521626530

### Solution

This PR only exists to run tests for https://github.com/dbt-labs/dbt-adapters/pull/372

### Checklist

- [x] N/A