### PR TITLE
Pin `github-release` workflow

### DIFF
--- a/.changes/1.9.0.md
+++ b/.changes/1.9.0.md
@@ -33,4 +33,3 @@
 - [@morsapaes](https://github.com/morsapaes) ([#120](https://github.com/dbt-labs/dbt-postgres/issues/120))
 - [@peterallenwebb](https://github.com/peterallenwebb) ([#123](https://github.com/dbt-labs/dbt-postgres/issues/123))
 - [@versusfacit](https://github.com/versusfacit) ([#85](https://github.com/dbt-labs/dbt-postgres/issues/85))
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
     needs:
       - build-release
       - release-prep
-    uses: dbt-labs/dbt-adapters/.github/workflows/github-release.yml@main
+    uses: dbt-labs/dbt-adapters/.github/workflows/github-release.yml@v1.10.3
     with:
       sha: ${{ needs.release-prep.outputs.release-sha }}
       version_number: ${{ inputs.version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ packages = ["dbt"]
 path = "dbt/adapters/postgres/__version__.py"
 
 [tool.hatch.envs.default]
+python = "3.9"
 dependencies = [
     "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",


### PR DESCRIPTION
### Problem

The GitHub release workflow no longer exists in `dbt-adapters`.

### Solution

Pin the reference to the last tag that includes this workflow.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-postgres/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
