### PR TITLE
Add support target_session_attrs

### DIFF
--- a/dbt/adapters/postgres/connections.py
+++ b/dbt/adapters/postgres/connections.py
@@ -35,6 +35,7 @@ class PostgresCredentials(Credentials):
     sslkey: Optional[str] = None
     sslrootcert: Optional[str] = None
     application_name: Optional[str] = "dbt"
+    target_session_attrs: Optional[str] = None
     retries: int = 1
 
     _ALIASES = {"dbname": "database", "pass": "password"}
@@ -63,6 +64,7 @@ class PostgresCredentials(Credentials):
             "sslkey",
             "sslrootcert",
             "application_name",
+            "target_session_attrs",
             "retries",
         )
 
@@ -132,6 +134,9 @@ class PostgresConnectionManager(SQLConnectionManager):
 
         if credentials.application_name:
             kwargs["application_name"] = credentials.application_name
+
+        if credentials.target_session_attrs:
+            kwargs["target_session_attrs"] = credentials.target_session_attrs
 
         def connect():
             handle = None

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -308,6 +308,24 @@ class TestPostgresAdapter(TestCase):
             application_name="dbt",
         )
 
+    @mock.patch("dbt.adapters.postgres.connections.psycopg2")
+    def test_set_target_session_attrs(self, psycopg2):
+        self.config.credentials = self.config.credentials.replace(target_session_attrs="any")
+        connection = self.adapter.acquire_connection("dummy")
+
+        psycopg2.connect.assert_not_called()
+        connection.handle
+        psycopg2.connect.assert_called_once_with(
+            dbname="postgres",
+            user="root",
+            host="thishostshouldnotexist",
+            password="password",
+            port=5432,
+            connect_timeout=10,
+            application_name="dbt",
+            target_session_attrs="any",
+        )
+
     @mock.patch.object(PostgresAdapter, "execute_macro")
     @mock.patch.object(PostgresAdapter, "_get_catalog_relations")
     def test_get_catalog_various_schemas(self, mock_get_relations, mock_execute):


### PR DESCRIPTION
### Problem
When specifying multiple hosts in a PostgreSQL cluster, it is possible to connect to the server in read-only mode.

### Solution
When specifying multiple hosts in a PostgreSQL cluster, it is necessary to pass the parameter target_session_attrs. This PR adds support for that parameter.